### PR TITLE
feat: add forwardRef capabilities

### DIFF
--- a/src/KeyboardAvoidingFlatList.tsx
+++ b/src/KeyboardAvoidingFlatList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {forwardRef, useImperativeHandle} from 'react'
 import {FlatList, FlatListProps} from 'react-native'
 import {
   ExternalKeyboardAvoidingContainerProps,
@@ -12,17 +12,24 @@ export interface KeyboardAvoidingFlatListProps<TItem>
     ExternalKeyboardAvoidingContainerProps {}
 
 export const KeyboardAvoidingFlatList = generic(
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-  <TItem extends unknown>(props: KeyboardAvoidingFlatListProps<TItem>) => {
-    const KeyboardAvoidingContainerProps = useKeyboardAvoidingContainerProps(
-      props,
-    )
+  forwardRef<FlatList, KeyboardAvoidingFlatListProps<any>>((props, ref) => {
+    const {
+      scrollViewRef,
+      ...KeyboardAvoidingContainerProps
+    } = useKeyboardAvoidingContainerProps(props)
+
+  // Use useImperativeHandle to expose the internal scrollViewRef to the parent
+  useImperativeHandle(ref, () => {
+    // @ts-expect-error We know it's a scrollview
+    return (scrollViewRef!.current as any)?.getScrollResponder() as ScrollView;
+  })
 
     return (
       <KeyboardAvoidingContainer
         {...KeyboardAvoidingContainerProps}
         ScrollViewComponent={FlatList}
+        scrollViewRef={scrollViewRef}
       />
     )
-  },
+  }),
 )

--- a/src/KeyboardAvoidingScrollView.tsx
+++ b/src/KeyboardAvoidingScrollView.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {forwardRef, useImperativeHandle} from 'react'
 import {ScrollView, ScrollViewProps} from 'react-native'
 import {
   ExternalKeyboardAvoidingContainerProps,
@@ -10,17 +10,26 @@ export interface KeyboardAvoidingScrollViewProps
   extends ScrollViewProps,
     ExternalKeyboardAvoidingContainerProps {}
 
-export const KeyboardAvoidingScrollView: React.FC<
+export const KeyboardAvoidingScrollView = forwardRef<
+  ScrollView,
   KeyboardAvoidingScrollViewProps
-> = props => {
-  const KeyboardAvoidingContainerProps = useKeyboardAvoidingContainerProps(
-    props,
-  )
+>((props, ref) => {
+  const {
+    scrollViewRef,
+    ...KeyboardAvoidingContainerProps
+  } = useKeyboardAvoidingContainerProps(props)
+
+  // Use useImperativeHandle to expose the internal scrollViewRef to the parent
+  useImperativeHandle(ref, () => {
+    // @ts-expect-error This is how other parts of the codebase use the ref
+    return (scrollViewRef!.current as any)?.getScrollResponder() as ScrollView;
+  })
 
   return (
     <KeyboardAvoidingContainer
       {...KeyboardAvoidingContainerProps}
       ScrollViewComponent={ScrollView}
+      scrollViewRef={scrollViewRef}
     />
   )
-}
+})

--- a/src/KeyboardAvoidingSectionList.tsx
+++ b/src/KeyboardAvoidingSectionList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {forwardRef, useImperativeHandle} from 'react'
 import {SectionList, SectionListProps} from 'react-native'
 import {
   ExternalKeyboardAvoidingContainerProps,
@@ -12,18 +12,26 @@ export interface KeyboardAvoidingSectionListProps<TItem extends {id: string}>
     ExternalKeyboardAvoidingContainerProps {}
 
 export const KeyboardAvoidingSectionList = generic(
-  <TItem extends {id: string}>(
-    props: KeyboardAvoidingSectionListProps<TItem>,
-  ) => {
-    const KeyboardAvoidingContainerProps = useKeyboardAvoidingContainerProps(
-      props,
-    )
+  forwardRef<SectionList, KeyboardAvoidingSectionListProps<any>>(
+    (props, ref) => {
+      const {
+        scrollViewRef,
+        ...KeyboardAvoidingContainerProps
+      } = useKeyboardAvoidingContainerProps(props)
 
-    return (
-      <KeyboardAvoidingContainer
-        {...KeyboardAvoidingContainerProps}
-        ScrollViewComponent={SectionList}
-      />
-    )
-  },
+      // Use useImperativeHandle to expose the internal scrollViewRef to the parent
+      useImperativeHandle(ref, () => {
+        // @ts-expect-error We know it's a scrollview
+        return (scrollViewRef!.current as any)?.getScrollResponder() as ScrollView;
+      })
+
+      return (
+        <KeyboardAvoidingContainer
+          {...KeyboardAvoidingContainerProps}
+          ScrollViewComponent={SectionList}
+          scrollViewRef={scrollViewRef}
+        />
+      )
+    },
+  ),
 )


### PR DESCRIPTION
This allows callers to get the underlying ScrollView to do things like `scrollTo`.