### PR TITLE
fix: avoid using SafeAreaView

### DIFF
--- a/src/KeyboardAvoidingContainer.tsx
+++ b/src/KeyboardAvoidingContainer.tsx
@@ -11,7 +11,6 @@ import {
   NativeSyntheticEvent,
   TextInput as NativeTextInput,
   Platform,
-  SafeAreaView,
   ScrollView,
   ScrollViewProps,
   StyleProp,
@@ -58,14 +57,14 @@ export const KeyboardAvoidingContainer = genericMemo(
     stickyFooterProps,
   }: KeyboardAvoidingContainerProps<TScrollViewProps>) => {
     return (
-      <SafeAreaView style={[styles.container, containerStyle]}>
+      <View style={[styles.container, containerStyle]}>
         <ScrollViewComponent ref={scrollViewRef} {...scrollViewProps} />
         {stickyFooter && (
           <View ref={stickyFooterRef} {...stickyFooterProps}>
             {stickyFooter}
           </View>
         )}
-      </SafeAreaView>
+      </View>
     )
   },
 )


### PR DESCRIPTION
The component should not enforce SafeAreaView at all. If a consumer wants to wrap it, they easily can.

BREAKING CHANGE: Anyone relying on the SafeAreaView will now need to enforce it themselves.